### PR TITLE
Add `iOS=1` option for testing against the local simulator on OS X

### DIFF
--- a/tests/DancePage.py
+++ b/tests/DancePage.py
@@ -17,21 +17,19 @@ class DancePage:
         self.artifact_folder = None
 
     def setup(self):
-        self.driver = webdriver.Remote('http://127.0.0.1:4723/wd/hub', {})
+        desired_caps = {}
+        if os.environ['iOS']:
+            desired_caps = {
+                'platformName': 'iOS',
+                'platformVersion': '11.4',
+                'deviceName': 'iPhone 7',
+                'browserName': 'Safari',
+            }
+        self.driver = webdriver.Remote('http://127.0.0.1:4723/wd/hub', desired_caps)
+
         self.driver.orientation = "LANDSCAPE"
         self.screenshot_folder = os.getenv('SCREENSHOT_PATH', '/tmp')
         self.artifact_folder = os.getenv('DEVICEFARM_LOG_DIR')
-
-        # TODO: Figure out local testing
-        # desired_caps = {
-        #     'platformName': 'Android',
-        #     # 'platformVersion': '8.0',
-        #     'avd': 'Nexus_4_API_22',
-        #     'deviceName': 'Android Emulator',
-        #     'browserName': 'Browser',
-        #     'automationName': 'UiAutomator2'
-        # }
-        # self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
 
     def teardown(self):
         self.driver.quit()


### PR DESCRIPTION
Sample usage:

1. Start the `appium` server.
2. `source bin/activate` in the dance-stress-test enlistment.
3. `iOS=1 py.test tests` to run against the local simulator (Xcode required).