### PR TITLE
Install dependencies using requirements file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ local
 wheelhouse
 requirements.txt
 test_bundle.zip
+.Python

--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ _Based on [this setup guide](https://github.com/aws-samples/aws-device-farm-samp
 1. Install additional project dependencies into your workspace
 
    ```bash
-   pip install pytest
-   pip install Appium-Python-Client
+   pip install -r project_requirements.txt
    ```
    
 1. Verify you can load and list tests

--- a/project_requirements.txt
+++ b/project_requirements.txt
@@ -1,0 +1,14 @@
+Appium_Python_Client==0.30
+atomicwrites==1.2.1
+attrs==18.2.0
+funcsigs==1.0.2
+more_itertools==4.3.0
+pathlib2==2.3.2
+pluggy==0.8.0
+py==1.7.0
+pytest==3.10.0
+scandir==1.9.0
+selenium==3.141.0
+setuptools==40.5.0
+six==1.11.0
+urllib3==1.24.1


### PR DESCRIPTION
When following the current instructions, here are the dependencies that get installed:

```
Winters-MBP:dance-stress-test winterdong$ cat requirements.txt 
Appium-Python-Client==0.48
atomicwrites==1.3.0
attrs==19.3.0
configparser==4.0.2
contextlib2==0.6.0.post1
funcsigs==1.0.2
importlib-metadata==0.23
more-itertools==5.0.0
packaging==19.2
pathlib2==2.3.5
pluggy==0.13.0
py==1.8.0
pyparsing==2.4.5
pytest==4.6.6
scandir==1.10.0
selenium==3.141.0
six==1.13.0
urllib3==1.25.7
wcwidth==0.1.7
zipp==0.6.0
```

Which don't match the checked-in dependencies in `aws_wheelhouse`. The resulting `test_bundle.zip` then fails when uploaded for a DeviceFarm run.

After this change it works for me. We might be able to tweak the build script so this isn't needed, but defining the exact dependencies might be useful anyways.