### PR TITLE
Add local selenium testing option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ wheelhouse
 requirements.txt
 test_bundle.zip
 .Python
+tests/*.pyc
+tests/__pycache__

--- a/README.md
+++ b/README.md
@@ -89,4 +89,15 @@ Due to how many tests there are, it might be easiest to run a subset of tests on
 
 ## Local testing
 
-Not solved yet! This is more difficult than it looks
+Local device testing using emulators - not solved yet! This is more difficult than it looks
+
+You can however test the functionality of your tests locally using Selenium and your browser:
+
+1. Install chromedriver by following these instructions: https://selenium-python.readthedocs.io/installation.html#drivers
+
+2. Pass in `automation_framework='selenium'` to the `DancePage` constructor like so:
+```python
+self.page = DancePage(automation_framework='selenium')
+```
+
+3. Run your tests. Artifacts will be created in your `/tmp` directory.

--- a/tests/DancePage.py
+++ b/tests/DancePage.py
@@ -1,7 +1,8 @@
 from datetime import datetime
 import json
 import os
-from appium import webdriver
+import appium
+import selenium
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.ui import Select
 from time import sleep
@@ -11,11 +12,12 @@ from selenium.common.exceptions import NoSuchElementException
 
 # Wrapper around an appium interface to a Dance Party page for readable tests
 class DancePage:
-    def __init__(self, origin='https://test-studio.code.org/'):
+    def __init__(self, origin='https://studio.code.org/', automation_framework='appium'):
         self.origin = origin
         self.driver = None
         self.screenshot_folder = None
         self.artifact_folder = None
+        self.automation_framework = automation_framework
 
     def setup(self):
         desired_caps = {}
@@ -26,11 +28,16 @@ class DancePage:
                 'deviceName': 'iPhone 7',
                 'browserName': 'Safari',
             }
-        self.driver = webdriver.Remote('http://127.0.0.1:4723/wd/hub', desired_caps)
+        if self.automation_framework == 'appium':
+            self.driver = appium.webdriver.Remote('http://127.0.0.1:4723/wd/hub', desired_caps)
+            self.driver.orientation = "LANDSCAPE"
+        elif self.automation_framework == 'selenium':
+            self.driver = selenium.webdriver.Chrome()
+        else:
+            raise ValueError('Unsupported driver "{}"'.format(self.automation_framework))
 
-        self.driver.orientation = "LANDSCAPE"
         self.screenshot_folder = os.getenv('SCREENSHOT_PATH', '/tmp')
-        self.artifact_folder = os.getenv('DEVICEFARM_LOG_DIR')
+        self.artifact_folder = os.getenv('DEVICEFARM_LOG_DIR', '/tmp')
 
     def teardown(self):
         self.driver.quit()


### PR DESCRIPTION
(Current base is `setup-fix` branch since it requires those changes; once https://github.com/code-dot-org/dance-stress-test/pull/4 is merged I can change the base to master.)

Iteration with device farm is pretty slow when starting to write new tests (especially for a new use case like the ML HoC tutorial); hopefully selenium works well enough to let us iterate locally on the test functionality. I only tried one existing dance party test but it seemed to work. In theory since both Selenium and Appium use the Webdriver API, the tests should be compatible with both...